### PR TITLE
Fix "Timers" settings text

### DIFF
--- a/DailyDuty/Windows/Settings/SettingsHeaders/TimersWindowConfiguration.cs
+++ b/DailyDuty/Windows/Settings/SettingsHeaders/TimersWindowConfiguration.cs
@@ -50,12 +50,12 @@ namespace DailyDuty.Windows.Settings.SettingsHeaders
 
         private void DisableEnableClickThrough()
         {
-            Draw.NotificationField("Enable Click-through", HeaderText, ref Settings.ClickThrough, "Enables/Disables the ability to move the Todo Window");
+            Draw.NotificationField("Enable Click-through", HeaderText, ref Settings.ClickThrough, "Enables/Disables the ability to move the Timers Window");
         }
 
         private void ShowHideWindow()
         {
-            Draw.NotificationField("Show Todo Window", HeaderText, ref Settings.Open, "Shows/Hides the Todo Window");
+            Draw.NotificationField("Show Timers Window", HeaderText, ref Settings.Open, "Shows/Hides the Timers Window");
         }
     }
 }


### PR DESCRIPTION
Replace references to "todos" with references to "timers" in the settings for the Timers window. Fixes #16 .