### PR TITLE
Small changes to Timers/ProgressBars

### DIFF
--- a/DailyDuty/Components/Graphical/DailyResetCountdown.cs
+++ b/DailyDuty/Components/Graphical/DailyResetCountdown.cs
@@ -11,6 +11,8 @@ internal class DailyResetCountdown : ICountdownTimer
     bool ICountdownTimer.Enabled => Service.Configuration.TimerSettings.DailyCountdownEnabled;
     public int ElementWidth => Service.Configuration.TimerSettings.TimerWidth;
     public Vector4 Color => Service.Configuration.TimerSettings.DailyCountdownColor;
+    public Vector4 BgColor => Service.Configuration.TimerSettings.DailyCountdownBgColor;
+    public bool ShortStrings => Service.Configuration.TimersWindowSettings.ShortStrings;
 
     void ICountdownTimer.DrawContents()
     {
@@ -18,6 +20,14 @@ internal class DailyResetCountdown : ICountdownTimer
         var totalHours = Time.NextDailyReset() - now;
         var percentage = (float) (1 - totalHours / TimeSpan.FromDays(1) );
 
-        Draw.DrawProgressBar(percentage, "Daily Reset", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color);
+        if (ShortStrings)
+        {
+            Draw.DrawProgressBar(percentage, "Day", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+        }
+        else
+        {
+            Draw.DrawProgressBar(percentage, "Daily Reset", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+        }
+        
     }
 }

--- a/DailyDuty/Components/Graphical/FashionReportResetCountdown.cs
+++ b/DailyDuty/Components/Graphical/FashionReportResetCountdown.cs
@@ -14,7 +14,9 @@ internal class FashionReportResetCountdown : ICountdownTimer
 {
     bool ICountdownTimer.Enabled => Service.Configuration.TimerSettings.FashionReportCountdownEnabled;
     public Vector4 Color => Service.Configuration.TimerSettings.FashionReportCountdownColor;
+    public Vector4 BgColor => Service.Configuration.TimerSettings.FashionReportCountdownBgColor;
     public int ElementWidth => Service.Configuration.TimerSettings.TimerWidth;
+    public bool ShortStrings => Service.Configuration.TimersWindowSettings.ShortStrings;
 
     void ICountdownTimer.DrawContents()
     {
@@ -36,6 +38,14 @@ internal class FashionReportResetCountdown : ICountdownTimer
             percentage = (float) (1 - totalHours / TimeSpan.FromDays(3) );
         }
 
-        Draw.DrawProgressBar(percentage, "Fashion Report", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color);
+        if (ShortStrings)
+        {
+            Draw.DrawProgressBar(percentage, "Fashion", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+        }
+        else
+        {
+            Draw.DrawProgressBar(percentage, "Fashion Report", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+        }
+        
     }
 }

--- a/DailyDuty/Components/Graphical/JumboCactpotResetCountdown.cs
+++ b/DailyDuty/Components/Graphical/JumboCactpotResetCountdown.cs
@@ -15,6 +15,8 @@ namespace DailyDuty.Components.Graphical
         public bool Enabled => Service.Configuration.TimerSettings.JumboCactpotCountdownEnabled;
         public int ElementWidth => Service.Configuration.TimerSettings.TimerWidth;
         public Vector4 Color => Service.Configuration.TimerSettings.JumboCactpotCountdownColor;
+        public Vector4 BgColor => Service.Configuration.TimerSettings.JumboCactpotCountdownBgColor;
+        public bool ShortStrings => Service.Configuration.TimersWindowSettings.ShortStrings;
 
         private DateTime NextReset => Service.Configuration.Current().JumboCactpot.NextReset;
         void ICountdownTimer.DrawContents()
@@ -23,7 +25,15 @@ namespace DailyDuty.Components.Graphical
             var totalHours = NextReset - now;
             var percentage = (float) (1 - totalHours / TimeSpan.FromDays(7) );
 
-            Draw.DrawProgressBar(percentage, "Jumbo Cactpot", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color);
+            if (ShortStrings)
+            {
+                Draw.DrawProgressBar(percentage, "Cactpot", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+            }
+            else
+            {
+                Draw.DrawProgressBar(percentage, "Jumbo Cactpot", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+            }
+            
         }
     }
 }

--- a/DailyDuty/Components/Graphical/TreasureMapCountdown.cs
+++ b/DailyDuty/Components/Graphical/TreasureMapCountdown.cs
@@ -15,6 +15,8 @@ namespace DailyDuty.Components.Graphical
         public bool Enabled => Service.Configuration.TimerSettings.TreasureMapCountdownEnabled;
         public int ElementWidth => Service.Configuration.TimerSettings.TimerWidth;
         public Vector4 Color => Service.Configuration.TimerSettings.TreasureMapCountdownColor;
+        public Vector4 BgColor => Service.Configuration.TimerSettings.TreasureMapCountdownBgColor;
+        public bool ShortStrings => Service.Configuration.TimersWindowSettings.ShortStrings;
 
         void ICountdownTimer.DrawContents()
         {
@@ -32,7 +34,15 @@ namespace DailyDuty.Components.Graphical
                 timeRemaining = TimeSpan.Zero;
             }
 
-            Draw.DrawProgressBar(percentage, "Treasure Map", timeRemaining, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color);
+            if (ShortStrings)
+            {
+                Draw.DrawProgressBar(percentage, "Map", timeRemaining, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+            }
+            else
+            {
+                Draw.DrawProgressBar(percentage, "Treasure Map", timeRemaining, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+            }
+            
         }
     }
 }

--- a/DailyDuty/Components/Graphical/WeeklyResetCountdown.cs
+++ b/DailyDuty/Components/Graphical/WeeklyResetCountdown.cs
@@ -10,7 +10,9 @@ internal class WeeklyResetCountdown : ICountdownTimer
 {
     bool ICountdownTimer.Enabled => Service.Configuration.TimerSettings.WeeklyCountdownEnabled;
     public Vector4 Color => Service.Configuration.TimerSettings.WeeklyCountdownColor;
+    public Vector4 BgColor => Service.Configuration.TimerSettings.WeeklyCountdownBgColor;
     public int ElementWidth => Service.Configuration.TimerSettings.TimerWidth;
+    public bool ShortStrings => Service.Configuration.TimersWindowSettings.ShortStrings;
 
     void ICountdownTimer.DrawContents()
     {
@@ -18,6 +20,14 @@ internal class WeeklyResetCountdown : ICountdownTimer
         var totalHours = Time.NextWeeklyReset() - now;
         var percentage = (float) (1 - totalHours / TimeSpan.FromDays(7) );
 
-        Draw.DrawProgressBar(percentage, "Weekly Reset", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color);
+        if (ShortStrings)
+        {
+            Draw.DrawProgressBar(percentage, "Week", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+        }
+        else
+        {
+            Draw.DrawProgressBar(percentage, "Weekly Reset", totalHours, ImGuiHelpers.ScaledVector2(ElementWidth, 20), Color, BgColor);
+        }
+        
     }
 }

--- a/DailyDuty/Data/SettingsObjects/CountdownTimerSettings.cs
+++ b/DailyDuty/Data/SettingsObjects/CountdownTimerSettings.cs
@@ -16,16 +16,21 @@ public class CountdownTimerSettings
 
     public bool DailyCountdownEnabled = true;
     public Vector4 DailyCountdownColor = Colors.Blue;
+    public Vector4 DailyCountdownBgColor = Colors.Black;
 
     public bool WeeklyCountdownEnabled = true;
     public Vector4 WeeklyCountdownColor = Colors.Purple;
+    public Vector4 WeeklyCountdownBgColor = Colors.Black;
 
     public bool FashionReportCountdownEnabled = false;
     public Vector4 FashionReportCountdownColor = Colors.ForestGreen;
+    public Vector4 FashionReportCountdownBgColor = Colors.Black;
 
     public bool TreasureMapCountdownEnabled = false;
     public Vector4 TreasureMapCountdownColor = Colors.Blue;
+    public Vector4 TreasureMapCountdownBgColor = Colors.Black;
 
     public bool JumboCactpotCountdownEnabled = false;
     public Vector4 JumboCactpotCountdownColor = Colors.Purple;
+    public Vector4 JumboCactpotCountdownBgColor = Colors.Black;
 }

--- a/DailyDuty/Data/SettingsObjects/WindowSettings/TimersWindowSettings.cs
+++ b/DailyDuty/Data/SettingsObjects/WindowSettings/TimersWindowSettings.cs
@@ -8,5 +8,7 @@ namespace DailyDuty.Data.SettingsObjects.WindowSettings
 {
     public class TimersWindowSettings : GenericWindowSettings
     {
+        public bool HideSeconds = false;
+        public bool ShortStrings = false;
     }
 }

--- a/DailyDuty/Utilities/Colors.cs
+++ b/DailyDuty/Utilities/Colors.cs
@@ -15,4 +15,5 @@ internal static class Colors
     public static Vector4 White = new Vector4(1.0f, 1.0f, 1.0f,1.0f);
     public static Vector4 Red = new Vector4(1.0f, 0.0f, 0.0f, 1.0f);
     public static Vector4 Green = new Vector4(0.0f, 1.0f, 0.0f, 1.0f);
+    public static Vector4 Black = new Vector4(0.0f, 0.0f, 0.0f, 1.0f);
 }

--- a/DailyDuty/Utilities/Draw.cs
+++ b/DailyDuty/Utilities/Draw.cs
@@ -13,9 +13,9 @@ namespace DailyDuty.Utilities;
 
 internal static class Draw
 {
-    public static void DrawProgressBar(float percentage, string prependText, TimeSpan remainingTime, Vector2 size, Vector4 barColor)
+    public static void DrawProgressBar(float percentage, string prependText, TimeSpan remainingTime, Vector2 size, Vector4 barColor, Vector4 bgColor)
     {
-        ImGui.PushStyleColor(ImGuiCol.FrameBg, new Vector4(0, 0, 0, 1));
+        ImGui.PushStyleColor(ImGuiCol.FrameBg, bgColor);
         ImGui.PushStyleColor(ImGuiCol.PlotHistogram, barColor);
 
         if (remainingTime > TimeSpan.Zero)

--- a/DailyDuty/Utilities/Strings.cs
+++ b/DailyDuty/Utilities/Strings.cs
@@ -9,25 +9,52 @@ namespace DailyDuty.Utilities;
 
 internal static class Strings
 {
+    public static bool HideSeconds => Service.Configuration.TimersWindowSettings.HideSeconds;
+    public static bool ShortStrings => Service.Configuration.TimersWindowSettings.ShortStrings;
     public static string FormatHours(this TimeSpan span)
     {
-        return $"{span.Hours:00}:{span.Minutes:00}:{span.Seconds:00}";
+        if (HideSeconds)
+        {
+            return $"{span.Hours:00}:{span.Minutes:00}";
+        }
+        else
+        {
+            return $"{span.Hours:00}:{span.Minutes:00}:{span.Seconds:00}";
+        }
+        
     }
 
     public static string FormatDays(this TimeSpan span)
     {
         string daysDisplay = ""; 
-
-        if (span.Days == 1)
+        
+        if (ShortStrings)
         {
-            daysDisplay = $"{span.Days} day, ";
+            if (span.Days >= 1)
+            {
+                daysDisplay = $"{span.Days}:";
+            }
         }
-        else if (span.Days > 1)
+        else
         {
-            daysDisplay = $"{span.Days} days, ";
+            if (span.Days == 1)
+            {
+                daysDisplay = $"{span.Days} day, ";
+            }
+            else if (span.Days > 1)
+            {
+                daysDisplay = $"{span.Days} days, ";
+            }
         }
 
-        return $"{daysDisplay}{span.Hours:00}:{span.Minutes:00}:{span.Seconds:00}";
+        if (HideSeconds)
+        {
+            return $"{daysDisplay}{span.Hours:00}:{span.Minutes:00}";
+        }
+        else
+        {
+            return $"{daysDisplay}{span.Hours:00}:{span.Minutes:00}:{span.Seconds:00}";
+        }
     }
 
     public static string FormatAuto(this TimeSpan span)

--- a/DailyDuty/Windows/Settings/SettingsHeaders/CountdownTimersConfiguration.cs
+++ b/DailyDuty/Windows/Settings/SettingsHeaders/CountdownTimersConfiguration.cs
@@ -27,11 +27,12 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
     {
         ImGui.Indent(15 * ImGuiHelpers.GlobalScale);
 
-        if (ImGui.BeginTable("CountdownTimersTable", 2))
+        if (ImGui.BeginTable("CountdownTimersTable", 3))
         {
             ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 200f * ImGuiHelpers.GlobalScale);
             ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 50f * ImGuiHelpers.GlobalScale);
-
+            ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 50f * ImGuiHelpers.GlobalScale);
+            
             DrawDailyResetCountdownOptions();
 
             DrawWeeklyResetCountdownOptions();
@@ -60,6 +61,10 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.TableNextColumn();
         ImGui.ColorEdit4("##Jumbo Cactpot Bar Color", ref Settings.JumboCactpotCountdownColor,
             ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        ImGui.ColorEdit4("##Jumbo Cactpot Bar Background Color", ref Settings.JumboCactpotCountdownBgColor,
+            ImGuiColorEditFlags.NoInputs);
     }
 
     private void DrawTreasureMapCountdownOptions()
@@ -72,6 +77,10 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.TableNextColumn();
         ImGui.ColorEdit4("##Treasure Map Bar Color", ref Settings.TreasureMapCountdownColor,
             ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        ImGui.ColorEdit4("##Treasure Map Bar Background Color", ref Settings.TreasureMapCountdownBgColor,
+            ImGuiColorEditFlags.NoInputs);
     }
 
     private void DrawCountdownWidthSlider()
@@ -81,7 +90,7 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.SameLine();
 
         ImGui.PushItemWidth(175 * ImGuiHelpers.GlobalScale);
-        ImGui.SliderInt("", ref Settings.TimerWidth, 170, 600);
+        ImGui.SliderInt("", ref Settings.TimerWidth, 86, 600);
         ImGui.PopItemWidth();
     }
 
@@ -95,6 +104,10 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.TableNextColumn();
         ImGui.ColorEdit4("##Fashion Report Reset Bar Color", ref Settings.FashionReportCountdownColor,
             ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        ImGui.ColorEdit4("##Fashion Report Reset Bar Background Color", ref Settings.FashionReportCountdownBgColor,
+            ImGuiColorEditFlags.NoInputs);
     }
 
     private void DrawWeeklyResetCountdownOptions()
@@ -105,7 +118,12 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
             "Show/Hide Weekly Reset Timer");
 
         ImGui.TableNextColumn();
-        ImGui.ColorEdit4("##Weekly Reset Bar Color", ref Settings.WeeklyCountdownColor, ImGuiColorEditFlags.NoInputs);
+        ImGui.ColorEdit4("##Weekly Reset Bar Color", ref Settings.WeeklyCountdownColor, 
+            ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        ImGui.ColorEdit4("##Weekly Reset Bar Background Color", ref Settings.WeeklyCountdownBgColor, 
+            ImGuiColorEditFlags.NoInputs);
     }
 
     private void DrawDailyResetCountdownOptions()
@@ -116,6 +134,11 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
             "Show/Hide Daily Reset Timer");
 
         ImGui.TableNextColumn();
-        ImGui.ColorEdit4("##Daily Reset Bar Color", ref Settings.DailyCountdownColor, ImGuiColorEditFlags.NoInputs);
+        ImGui.ColorEdit4("##Daily Reset Bar Color", ref Settings.DailyCountdownColor, 
+            ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        ImGui.ColorEdit4("##Daily Reset Bar Background Color", ref Settings.DailyCountdownBgColor, 
+            ImGuiColorEditFlags.NoInputs);
     }
 }

--- a/DailyDuty/Windows/Settings/SettingsHeaders/CountdownTimersConfiguration.cs
+++ b/DailyDuty/Windows/Settings/SettingsHeaders/CountdownTimersConfiguration.cs
@@ -27,11 +27,12 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
     {
         ImGui.Indent(15 * ImGuiHelpers.GlobalScale);
 
-        if (ImGui.BeginTable("CountdownTimersTable", 3))
+        if (ImGui.BeginTable("CountdownTimersTable", 4))
         {
             ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 200f * ImGuiHelpers.GlobalScale);
             ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 50f * ImGuiHelpers.GlobalScale);
             ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 50f * ImGuiHelpers.GlobalScale);
+            ImGui.TableSetupColumn("", ImGuiTableColumnFlags.WidthFixed, 100f * ImGuiHelpers.GlobalScale);
             
             DrawDailyResetCountdownOptions();
 
@@ -65,6 +66,13 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.TableNextColumn();
         ImGui.ColorEdit4("##Jumbo Cactpot Bar Background Color", ref Settings.JumboCactpotCountdownBgColor,
             ImGuiColorEditFlags.NoInputs);
+
+        ImGui.TableNextColumn();
+        if (ImGui.Button("Reset Cactpot", ImGuiHelpers.ScaledVector2(100, 25)))
+        {
+            Settings.JumboCactpotCountdownColor = Colors.Purple;
+            Settings.JumboCactpotCountdownBgColor = Colors.Black;
+        }
     }
 
     private void DrawTreasureMapCountdownOptions()
@@ -81,6 +89,13 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.TableNextColumn();
         ImGui.ColorEdit4("##Treasure Map Bar Background Color", ref Settings.TreasureMapCountdownBgColor,
             ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        if (ImGui.Button("Reset Map", ImGuiHelpers.ScaledVector2(100, 25)))
+        {
+            Settings.TreasureMapCountdownColor = Colors.Blue;
+            Settings.TreasureMapCountdownBgColor = Colors.Black;
+        }
     }
 
     private void DrawCountdownWidthSlider()
@@ -108,6 +123,13 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.TableNextColumn();
         ImGui.ColorEdit4("##Fashion Report Reset Bar Background Color", ref Settings.FashionReportCountdownBgColor,
             ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        if (ImGui.Button("Reset Fashion", ImGuiHelpers.ScaledVector2(100, 25)))
+        {
+            Settings.FashionReportCountdownColor = Colors.ForestGreen;
+            Settings.FashionReportCountdownBgColor = Colors.Black;
+        }
     }
 
     private void DrawWeeklyResetCountdownOptions()
@@ -124,6 +146,13 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.TableNextColumn();
         ImGui.ColorEdit4("##Weekly Reset Bar Background Color", ref Settings.WeeklyCountdownBgColor, 
             ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        if (ImGui.Button("Reset Weekly", ImGuiHelpers.ScaledVector2(100, 25)))
+        {
+            Settings.WeeklyCountdownColor = Colors.Purple;
+            Settings.WeeklyCountdownBgColor = Colors.Black;
+        }
     }
 
     private void DrawDailyResetCountdownOptions()
@@ -140,5 +169,12 @@ internal class CountdownTimersConfiguration : ICollapsibleHeader
         ImGui.TableNextColumn();
         ImGui.ColorEdit4("##Daily Reset Bar Background Color", ref Settings.DailyCountdownBgColor, 
             ImGuiColorEditFlags.NoInputs);
+        
+        ImGui.TableNextColumn();
+        if (ImGui.Button("Reset Daily", ImGuiHelpers.ScaledVector2(100, 25)))
+        {
+            Settings.DailyCountdownColor = Colors.Blue;
+            Settings.DailyCountdownBgColor = Colors.Black;
+        }
     }
 }

--- a/DailyDuty/Windows/Settings/SettingsHeaders/TimersWindowConfiguration.cs
+++ b/DailyDuty/Windows/Settings/SettingsHeaders/TimersWindowConfiguration.cs
@@ -32,6 +32,10 @@ namespace DailyDuty.Windows.Settings.SettingsHeaders
             HideInDuty();
 
             OpacitySlider();
+
+            ShowHideSeconds();
+
+            UseShortStrings();
             
             ImGui.Indent(-15 * ImGuiHelpers.GlobalScale);
         }
@@ -56,6 +60,16 @@ namespace DailyDuty.Windows.Settings.SettingsHeaders
         private void ShowHideWindow()
         {
             Draw.NotificationField("Show Timers Window", HeaderText, ref Settings.Open, "Shows/Hides the Timers Window");
+        }
+        
+        private void UseShortStrings()
+        {
+            Draw.NotificationField("Show Less Text", HeaderText, ref Settings.ShortStrings, "Make Timer labels less verbose (Weekly Reset: nDays, HH:MM:SS -> Week: D:HH:MM:SS)");
+        }
+
+        private void ShowHideSeconds()
+        {
+            Draw.NotificationField("Hide Seconds", HeaderText, ref Settings.HideSeconds, "Omit Seconds from timer display (HH:MM:SS -> HH:MM)");
         }
     }
 }


### PR DESCRIPTION
ADD:
- Show/Hide 'Seconds' display on timers (Default: False/Existing behavior)
`HH:MM:SS -> HH:MM`
- Shorter strings on timer labels (Default: False/Existing behavior)
`Weekly Reset: nDays, HH:MM:SS -> Week: D:HH:MM:SS`
- ProgressBar Background color configuration (Default: Colors.Black)

CHANGE:
- Minimum length for ProgressBar from 170px -> 86px

KNOWN ISSUES:
- None