### PR TITLE
Display roulettes separately in todo window

### DIFF
--- a/DailyDuty/Data/SettingsObjects/Daily/DutyRouletteSettings.cs
+++ b/DailyDuty/Data/SettingsObjects/Daily/DutyRouletteSettings.cs
@@ -4,6 +4,7 @@ namespace DailyDuty.Data.SettingsObjects.Daily
 {
     public class DutyRouletteSettings : GenericSettings
     {
+        public bool SingleTask = false;
         public TrackedRoulette[] TrackedRoulettes =
         {
             new(RouletteType.Expert),

--- a/DailyDuty/Interfaces/ICompletable.cs
+++ b/DailyDuty/Interfaces/ICompletable.cs
@@ -1,5 +1,7 @@
 ﻿using DailyDuty.Data.Enums;
 using DailyDuty.Data.SettingsObjects;
+using DailyDuty.Data.SettingsObjects.Windows.SubComponents;
+using ImGuiNET;
 
 namespace DailyDuty.Interfaces
 {
@@ -10,5 +12,16 @@ namespace DailyDuty.Interfaces
         public GenericSettings GenericSettings { get; }
 
         public bool IsCompleted();
+        public void DrawTask(TaskColors colors, bool showCompletedTasks)
+        {
+            if (IsCompleted() == false && GenericSettings.Enabled)
+            {
+                ImGui.TextColored(colors.IncompleteColor, HeaderText);
+            }
+            else if (IsCompleted() == true && GenericSettings.Enabled && showCompletedTasks)
+            {
+                ImGui.TextColored(colors.CompleteColor, HeaderText);
+            }
+        }
     }
 }

--- a/DailyDuty/Interfaces/ITaskCategoryDisplay.cs
+++ b/DailyDuty/Interfaces/ITaskCategoryDisplay.cs
@@ -22,7 +22,7 @@ namespace DailyDuty.Interfaces
 
             foreach (var module in Tasks)
             {
-                DrawTaskStatus(module);
+                module.DrawTask(Colors, ShowCompletedTasks);
             }
 
             bool allTasksComplete = Tasks
@@ -43,19 +43,6 @@ namespace DailyDuty.Interfaces
             return Tasks
                 .Where(task => task.GenericSettings.Enabled)
                 .All(task => task.IsCompleted());
-        }
-
-        private void DrawTaskStatus(ICompletable task)
-        {
-            if (task.IsCompleted() == false && task.GenericSettings.Enabled)
-            {
-                ImGui.TextColored(Colors.IncompleteColor, task.HeaderText);
-            }
-            else if (task.IsCompleted() == true && task.GenericSettings.Enabled && ShowCompletedTasks)
-            {
-                ImGui.TextColored(Colors.CompleteColor, task.HeaderText);
-            }
-
         }
     }
 }

--- a/DailyDuty/Modules/Daily/DutyRoulette.cs
+++ b/DailyDuty/Modules/Daily/DutyRoulette.cs
@@ -4,6 +4,7 @@ using DailyDuty.Data.Enums;
 using DailyDuty.Data.ModuleData.DutyRoulette;
 using DailyDuty.Data.SettingsObjects;
 using DailyDuty.Data.SettingsObjects.Daily;
+using DailyDuty.Data.SettingsObjects.Windows.SubComponents;
 using DailyDuty.Interfaces;
 using DailyDuty.Utilities;
 using Dalamud.Game.Text.SeStringHandling;
@@ -112,6 +113,26 @@ namespace DailyDuty.Modules.Daily
         public bool IsCompleted()
         {
             return RemainingRoulettesCount() == 0;
+        }
+
+        public void DrawTask(TaskColors colors, bool showCompletedTasks)
+        {
+            if (GenericSettings.Enabled == false)
+            {
+                return;
+            }
+            
+            foreach (var tracked in Settings.TrackedRoulettes)
+            {
+                if (tracked.Completed == false && tracked.Tracked == true)
+                {
+                    ImGui.TextColored(colors.IncompleteColor, $"{tracked.Type} Roulette");
+                }
+                else if (tracked.Completed == true && tracked.Tracked == true && showCompletedTasks)
+                {
+                    ImGui.TextColored(colors.CompleteColor, $"{tracked.Type} Roulette");
+                }
+            }
         }
 
         public void SendNotification()

--- a/DailyDuty/Modules/Daily/DutyRoulette.cs
+++ b/DailyDuty/Modules/Daily/DutyRoulette.cs
@@ -121,16 +121,30 @@ namespace DailyDuty.Modules.Daily
             {
                 return;
             }
-            
-            foreach (var tracked in Settings.TrackedRoulettes)
+
+            if(Settings.SingleTask)
             {
-                if (tracked.Completed == false && tracked.Tracked == true)
+                if (IsCompleted() == false)
                 {
-                    ImGui.TextColored(colors.IncompleteColor, $"{tracked.Type} Roulette");
+                    ImGui.TextColored(colors.IncompleteColor, HeaderText);
                 }
-                else if (tracked.Completed == true && tracked.Tracked == true && showCompletedTasks)
+                else if (IsCompleted() == true && showCompletedTasks)
                 {
-                    ImGui.TextColored(colors.CompleteColor, $"{tracked.Type} Roulette");
+                    ImGui.TextColored(colors.CompleteColor, HeaderText);
+                }
+            }
+            else
+            {
+                foreach (var tracked in Settings.TrackedRoulettes)
+                {
+                    if (tracked.Completed == false && tracked.Tracked == true)
+                    {
+                        ImGui.TextColored(colors.IncompleteColor, $"{tracked.Type} Roulette");
+                    }
+                    else if (tracked.Completed == true && tracked.Tracked == true && showCompletedTasks)
+                    {
+                        ImGui.TextColored(colors.CompleteColor, $"{tracked.Type} Roulette");
+                    }
                 }
             }
         }
@@ -145,6 +159,9 @@ namespace DailyDuty.Modules.Daily
 
         public void NotificationOptions()
         {
+            ImGui.Checkbox("Single Todo Task", ref Settings.SingleTask);
+            ImGuiComponents.HelpMarker("Display this module's status as a single task in the todo window instead of each roulette separate");
+
             Draw.OnLoginReminderCheckbox(Settings);
 
             Draw.OnTerritoryChangeCheckbox(Settings);


### PR DESCRIPTION
Display all roulettes separately instead if grouping them together into a single item