### PR TITLE
WondrousTails instance notifications not working after rework

### DIFF
--- a/DailyDuty/ModuleConfiguration/WondrousTails.cs
+++ b/DailyDuty/ModuleConfiguration/WondrousTails.cs
@@ -127,6 +127,7 @@ namespace DailyDuty.ModuleConfiguration
 
                 if (Draw.Checkbox(Strings.Module.WondrousTailsInstanceNotificationsLabel, ref Settings.InstanceNotifications, Strings.Module.WondrousTailsInstanceNotificationsDescription))
                 {
+                    Settings.ZoneChangeReminder = Settings.InstanceNotifications;
                     Service.LogManager.LogMessage(ModuleType.WondrousTails, "Instance Notifications " + (Settings.InstanceNotifications ? "Enabled" : "Disabled"));
                     Service.CharacterConfiguration.Save();
                 }


### PR DESCRIPTION
Resolves #52
I had noticed the bug independently of the issue, but had not yet found the time to look for it.

This is the simplest fix. If you want to add an additional checkbox in the settings, then just close the PR