### PR TITLE
Add Human Timer Format, use translation strings for formats

### DIFF
--- a/DailyDuty/Configuration/Components/TimerSettings.cs
+++ b/DailyDuty/Configuration/Components/TimerSettings.cs
@@ -3,26 +3,27 @@ using System;
 using System.Numerics;
 using System.Text;
 using DailyDuty.Utilities;
+using DailyDuty.Localization;
 
 namespace DailyDuty.Configuration.Components;
 
 [Flags]
 public enum TimerStyle
 {
-    Days = 0b1000,
-    Hours = 0b0100,
-    Minutes = 0b0010,
-    Seconds = 0b0001,
+    Labelled = 0b10000,
+    Days = 0b01000,
+    Hours = 0b00100,
+    Minutes = 0b00010,
+    Seconds = 0b00001,
 
+    Human = Labelled | Days | Hours | Minutes | Seconds,
     Full = Days | Hours | Minutes | Seconds,
-    DaysNoSeconds = Days | Hours | Minutes,
-    NoDays = Hours | Minutes | Seconds,
-    NoDaysNoSeconds = Hours | Minutes,
+    NoSeconds = Days | Hours | Minutes,
 }
 
 public class TimerSettings
 {
-    public Setting<TimerStyle> TimerStyle = new(Components.TimerStyle.Full);
+    public Setting<TimerStyle> TimerStyle = new(Components.TimerStyle.Human);
     public Setting<Vector4> BackgroundColor = new(Colors.Black);
     public Setting<Vector4> ForegroundColor = new(Colors.Purple);
     public Setting<Vector4> TextColor = new(Colors.White);
@@ -39,26 +40,21 @@ public static class TimerStyleExtensions
 {
     public static string GetLabel(this TimerStyle style)
     {
-        if (style == 0)
-            return string.Empty;
-
-        var sb = new StringBuilder(16);
-        if (style.HasFlag(TimerStyle.Days)) sb.Append($"D").Append('.');
-        if (style.HasFlag(TimerStyle.Hours)) sb.Append($"HH").Append(':');
-        if (style.HasFlag(TimerStyle.Minutes)) sb.Append($"MM").Append(':');
-        if (style.HasFlag(TimerStyle.Seconds)) sb.Append($"SS").Append(':');
-
-        return sb.ToString(0, sb.Length - 1);
+        switch (style) {
+            case TimerStyle.Human: return Strings.UserInterface.Timers.HumanStyle;
+            case TimerStyle.Full: return Strings.UserInterface.Timers.FullStyle;
+            case TimerStyle.NoSeconds: return Strings.UserInterface.Timers.NoSecondsStyle;
+            default: return string.Empty;
+        }
     }
 
     public static IEnumerable<TimerStyle> GetConfigurableStyles()
     {
         return new List<TimerStyle>()
         {
+            TimerStyle.Human,
             TimerStyle.Full,
-            TimerStyle.DaysNoSeconds,
-            TimerStyle.NoDays,
-            TimerStyle.NoDaysNoSeconds
+            TimerStyle.NoSeconds,
         };
     }
 }

--- a/DailyDuty/Localization/Strings.cs
+++ b/DailyDuty/Localization/Strings.cs
@@ -362,6 +362,14 @@ public class Timers
     public string HideLabel => Loc.Localize("Timers_HideLabel", "Hide Label");
     public string HideTime => Loc.Localize("Timers_HideTime", "Hide Time");
     public string HideCompleted => Loc.Localize("Timers_HideCompleted", "Hide Completed Tasks");
+    public string HumanStyle => Loc.Localize("Timers_HumanStyle", "Human (e.g. '3 hours')");
+    public string FullStyle => Loc.Localize("Timers_FullStyle", "Full (D.HH:MM:SS)");
+    public string NoSecondsStyle => Loc.Localize("Timers_NoSecondsStyle", "No Seconds (D.HH:MM)");
+    public string NumDays => Loc.Localize("Timers_NumDays", "{0} days");
+    public string DayPlusHours => Loc.Localize("Timers_DayPlusHours", "{0} day, {1} hours");
+    public string NumHours => Loc.Localize("Timers_NumHours", "{0} hours");
+    public string NumMins => Loc.Localize("Timers_NumMins", "{0} minutes");
+    public string NumSecs => Loc.Localize("Timers_NumSecs", "{0} seconds");
 }
 
 public class Teleport

--- a/DailyDuty/UserInterface/Windows/TimersOverlayWindow.cs
+++ b/DailyDuty/UserInterface/Windows/TimersOverlayWindow.cs
@@ -17,7 +17,7 @@ namespace DailyDuty.UserInterface.Windows;
 internal class TimersOverlayWindow : Window, IDisposable
 {
     private static TimersOverlaySettings Settings => Service.ConfigurationManager.CharacterConfiguration.TimersOverlay;
-    
+
     private List<ITimerComponent> trackedTasks = new();
 
     public TimersOverlayWindow() : base($"###DailyDutyTimersOverlayWindow+{Service.ConfigurationManager.CharacterConfiguration.CharacterData.Name}")
@@ -89,7 +89,7 @@ internal class TimersOverlayWindow : Window, IDisposable
             DrawAllTimers(trackedTasks);
         }
     }
-    
+
     public override void PostDraw()
     {
         ImGui.PopStyleColor();
@@ -222,16 +222,20 @@ internal class TimersOverlayWindow : Window, IDisposable
 
     public static string FormatTimespan(TimeSpan span, TimerStyle style)
     {
-        if (style == 0)
-            return string.Empty;
-
-        var sb = new StringBuilder(16);
-
-        if (style.HasFlag(TimerStyle.Days)) sb.Append($"{span.Days:D1}").Append('.');
-        if (style.HasFlag(TimerStyle.Hours)) sb.Append($"{span.Hours:D2}").Append(':');
-        if (style.HasFlag(TimerStyle.Minutes)) sb.Append($"{span.Minutes:D2}").Append(':');
-        if (style.HasFlag(TimerStyle.Seconds)) sb.Append($"{span.Seconds:D2}").Append(':');
-
-        return sb.ToString(0, sb.Length - 1);
+        switch (style) {
+            case TimerStyle.Human:
+                // Human Style just shows the highest order nonzero field.
+                if (span.Days > 1) return String.Format(Strings.UserInterface.Timers.NumDays, span.Days);
+                if (span.Days == 1) return String.Format(Strings.UserInterface.Timers.DayPlusHours, span.Days, span.Hours);
+                else if (span.Hours >= 1) return String.Format(Strings.UserInterface.Timers.NumHours, span.Hours);
+                else if (span.Minutes >= 1) return String.Format(Strings.UserInterface.Timers.NumMins, span.Minutes);
+                else return String.Format(Strings.UserInterface.Timers.NumSecs, span.Seconds);
+            case TimerStyle.Full:
+                return $"{(span.Days>=1?$"{span.Days}.":"")}{span.Hours:D2}:{span.Minutes:D2}:{span.Seconds:D2}";
+            case TimerStyle.NoSeconds:
+                return $"{(span.Days>=1?$"{span.Days}.":"")}{span.Hours:D2}:{span.Minutes:D2}";
+            default:
+                return String.Empty;
+        }
     }
 }


### PR DESCRIPTION
Human Style, fixes #87 with slightly different format than specified in that ticket:

* 2+ days: "n days"
* 1 day: "1 day, n hours"
* <1 day: "n hours", "n minutes", "n seconds", only showing the highest order.

All strings are in the translations stringset, but I didn't actually add translations for them.