### PR TITLE
Cache node visilbity data

### DIFF
--- a/DailyDuty/System/TodoController.cs
+++ b/DailyDuty/System/TodoController.cs
@@ -23,7 +23,8 @@ public class TodoController : IDisposable
     private bool configChanged;
     private TodoUiController? uiController;
     private Vector2? holdOffset;
-    private readonly Dictionary<ModuleName, (bool, bool, bool)> displayDataCache = new();
+    private readonly Dictionary<ModuleName, DisplayData> displayDataCache = new();
+    private record DisplayData(bool ShowModule, bool ShowHeader, bool ShowCategory);
 
     public void Dispose() => Unload();
     
@@ -136,17 +137,16 @@ public class TodoController : IDisposable
             }
 
             var name = module.ModuleName;
-            var display = (
+            var display = new DisplayData(
                 GetModuleActiveState(module) && enabled || Config.PreviewMode,
                 Config.ShowHeaders,
                 enabled);
 
             if (!displayDataCache.TryGetValue(name, out var cached) || !cached.Equals(display) || wasStyleChanged)
             {
-                PluginLog.Debug($"cache miss ({type}/{name}) cachedChanged={!cached.Equals(display)} wasStyleChanged={wasStyleChanged}");
-                uiController?.UpdateModule(type, name, GetModuleTodoLabel(module), display.Item1);
-                uiController?.UpdateCategoryHeader(type, GetCategoryLabel(type), display.Item2);
-                uiController?.UpdateCategory(type, display.Item3);
+                uiController?.UpdateModule(type, name, GetModuleTodoLabel(module), display.ShowModule);
+                uiController?.UpdateCategoryHeader(type, GetCategoryLabel(type), display.ShowHeader);
+                uiController?.UpdateCategory(type, display.ShowCategory);
                 displayDataCache[name] = display;
             }
         }


### PR DESCRIPTION
Please consider this as just a proof-of-concept or general idea, but I was looking into ways to further reduce the frame update time in addition to the large improvements that have already been made in the most recent testing version.

It's a little messy but the basic idea is to avoid the native calls required for updating `AtkResNode`s by caching node visibility. This would normally miss the case where label names changed, but we can seemingly exploit the style change flag to catch those cases too. I tested this a bit and it seemed to work for me, though it's quite likely I missed some important cases.

After this change the update time was reduced by around 45% for me (0.1 ms to 0.055 ms), which was enough that I thought I'd share.

Thanks for the plugin and thanks for taking the time to read this.