### PR TITLE
Use parallel iteration of ordered lists in GetIncompleteCount

### DIFF
--- a/DailyDuty/Abstracts/BaseModule.cs
+++ b/DailyDuty/Abstracts/BaseModule.cs
@@ -166,14 +166,49 @@ public abstract class BaseModule : IDisposable
     {
         if (config.Count != data.Count) throw new Exception("Task and Data array size are mismatched. Unable to calculate IncompleteCount");
 
-        var queryResult = 
-            from configTask in config
-            join dataTask in data on configTask.RowId equals dataTask.RowId
-            where 
-                (configTask.Enabled && configTask.TargetCount is not 0 && dataTask.CurrentCount < configTask.TargetCount) ||
-                (configTask.Enabled && configTask.TargetCount is 0 && !dataTask.Complete)
-            select configTask;
+        var count = 0;
+        var len = config.Count;
+        for (var i = 0; i < len; i++)
+        {
+            var configTask = config.ConfigList[i];
+            var dataTask = data.DataList[i];
 
-        return queryResult.Count();
+            if (configTask.RowId != dataTask.RowId)
+            {
+                throw new Exception($"Task and Data rows are mismatched. Unable to calculate IncompleteCount (task={configTask.RowId} data={dataTask.RowId}).");
+            }
+
+            if (configTask.Enabled)
+            {
+                if ((configTask.TargetCount != 0 && dataTask.CurrentCount < configTask.TargetCount)
+                    || (configTask.TargetCount == 0 && !dataTask.Complete))
+                {
+                    count += 1;
+                }
+            }
+        }
+
+        return count;
+
+        // var queryResult =
+        //     from configTask in config
+        //     join dataTask in data on configTask.RowId equals dataTask.RowId
+        //     where
+        //         (configTask.Enabled && configTask.TargetCount is not 0 && dataTask.CurrentCount < configTask.TargetCount) ||
+        //         (configTask.Enabled && configTask.TargetCount is 0 && !dataTask.Complete)
+        //     select configTask;
+        //
+        // var queryCount = queryResult.Count();
+        //
+        // if (count != queryCount)
+        // {
+        //     PluginLog.Error($"GetIncompleteCount ERR [{typeof(T).FullName}]: (count={count} queryCount={queryCount} total={config.Count})");
+        // }
+        // else
+        // {
+        //     // PluginLog.Information($"GetIncompleteCount OK  [{typeof(T).FullName}]: (count={count} queryCount={queryCount} total={config.Count})");
+        // }
+        //
+        // return queryCount;
     }
 }

--- a/DailyDuty/Models/LuminaTaskConfigList.cs
+++ b/DailyDuty/Models/LuminaTaskConfigList.cs
@@ -58,6 +58,11 @@ public class LuminaTaskConfigList<T> : IConfigDrawable, ICollection<LuminaTaskCo
         }
     }
 
+    public void Sort()
+    {
+        ConfigList = ConfigList.OrderBy(e => e.RowId).ToList();
+    }
+
     private void DrawStandardConfigList(Action saveAction)
     {
         foreach (var configEntry in ConfigList)

--- a/DailyDuty/Models/LuminaTaskDataList.cs
+++ b/DailyDuty/Models/LuminaTaskDataList.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
+using System.Linq;
 using DailyDuty.System.Localization;
 using ImGuiNET;
 using KamiLib.Caching;
@@ -56,7 +57,12 @@ public class LuminaTaskDataList<T> : IDrawable, ICollection<LuminaTaskData<T>> w
             ImGui.EndTable();
         }
     }
-    
+
+    public void Sort()
+    {
+        DataList = DataList.OrderBy(e => e.RowId).ToList();
+    }
+
     private void DrawStandardDataList()
     {
         foreach (var dataEntry in DataList)

--- a/DailyDuty/System/Helpers/LuminaTaskUpdater.cs
+++ b/DailyDuty/System/Helpers/LuminaTaskUpdater.cs
@@ -22,13 +22,13 @@ public class LuminaTaskUpdater<T> where T : ExcelRow
 
     public void UpdateConfig(LuminaTaskConfigList<T> configValues)
     {
-        if (configValues.ConfigList.Count != luminaRows.Count())
+        if (configValues.Count != luminaRows.Count())
         {
             foreach (var luminaEntry in luminaRows)
             {
-                if (!configValues.ConfigList.Any(task => task.RowId == luminaEntry.RowId))
+                if (!configValues.Any(task => task.RowId == luminaEntry.RowId))
                 {
-                    configValues.ConfigList.Add(new LuminaTaskConfig<T>
+                    configValues.Add(new LuminaTaskConfig<T>
                     {
                         RowId = luminaEntry.RowId,
                         Enabled = false,
@@ -39,6 +39,8 @@ public class LuminaTaskUpdater<T> where T : ExcelRow
             
             module.SaveConfig();
         }
+
+        configValues.Sort();
     }
     
     public void UpdateData(LuminaTaskDataList<T> dataList)
@@ -60,5 +62,7 @@ public class LuminaTaskUpdater<T> where T : ExcelRow
             
             module.SaveData();
         }
+
+        dataList.Sort();
     }
 }


### PR DESCRIPTION
Based on your comments on the last PR, I looked into `GetIncompleteCount`.

My thinking here is that if we can guarantee that config and data are of the same length (already guaranteed), contain the exact same `RowId`s (I think guaranteed after `LuminaTaskUpdater.UpdateConfig` and `LuminaTaskUpdater.UpdateData`?), and are in the exact same order (in practice likely true but perhaps not not guaranteed), we can use parallel iteration of both lists and avoid the LINQ joins.

To make the last part true (sorting guaranteed) I sort the lists after `LuminaTaskUpdater`'s update functions, which is maybe the only location we need to do this based on what I could find.

I think this makes sense, but I left some debug code commented out at the end which you might also want to use to sanity check the old vs new methods. Assuming this approach is feasible, I think the speedups we're likely to see here depend on the user's configuration, but with my relatively simple config I see a speed-up of around 25% (0.550 to 0.400 or so).