### PR TITLE
Add option for only expert roulette complete when tomecapped

### DIFF
--- a/DailyDuty/Localization/Strings.Designer.cs
+++ b/DailyDuty/Localization/Strings.Designer.cs
@@ -609,6 +609,24 @@ namespace DailyDuty.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Duty Roulette: Expert complete when Tomecapped
+        /// </summary>
+        internal static string ExpertCompleteWhenTomeCapped {
+            get {
+                return ResourceManager.GetString("ExpertCompleteWhenTomeCapped", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Marks only Duty Roulette: Expert complete when you are at the tomestone weekly limit.
+        /// </summary>
+        internal static string ExpertCompleteWhenTomeCappedHelp {
+            get {
+                return ResourceManager.GetString("ExpertCompleteWhenTomeCappedHelp", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Fashion Report.
         /// </summary>
         internal static string FashionReport {

--- a/DailyDuty/Localization/Strings.resx
+++ b/DailyDuty/Localization/Strings.resx
@@ -271,6 +271,12 @@ Limited to once per 5 mins</value>
     <data name="CompleteWhenTomeCapped" xml:space="preserve">
         <value>Complete When Tomecapped</value>
     </data>
+    <data name="ExpertCompleteWhenTomeCapped" xml:space="preserve">
+        <value>Duty Roulette: Expert complete when Tomecapped</value>
+    </data>
+    <data name="ExpertCompleteWhenTomeCappedHelp" xml:space="preserve">
+        <value>Marks only Duty Roulette: Expert complete when you are at the tomestone weekly limit.</value>
+    </data>
     <data name="CompleteWhenTomeCappedHelp" xml:space="preserve">
         <value>Marks task as complete when you are at the tomestone weekly limit</value>
     </data>

--- a/DailyDuty/Modules/DutyRoulette.cs
+++ b/DailyDuty/Modules/DutyRoulette.cs
@@ -36,11 +36,13 @@ public class DutyRouletteData : ModuleTaskData<ContentRoulette> {
             (Strings.WeeklyTomestoneLimit, ExpertTomestoneCap.ToString()),
             (Strings.AtWeeklyTomestoneLimit, AtTomeCap.ToString()),
         ]);
+        TaskData.Draw();
     }
 }
 
 public class DutyRouletteConfig : ModuleTaskConfig<ContentRoulette> {
     public bool CompleteWhenCapped;
+    public bool ExpertCompleteWhenCapped;
     public bool ClickableLink = true;
     public bool ColorContentFinder = true;
     public Vector4 CompleteColor = KnownColor.LimeGreen.Vector();
@@ -51,6 +53,7 @@ public class DutyRouletteConfig : ModuleTaskConfig<ContentRoulette> {
 
         configChanged |= ImGui.Checkbox(Strings.ClickableLink, ref ClickableLink);
         configChanged |= ImGui.Checkbox(Strings.CompleteWhenTomeCapped, ref CompleteWhenCapped);
+        configChanged |= ImGui.Checkbox(Strings.ExpertCompleteWhenTomeCapped, ref ExpertCompleteWhenCapped);
         configChanged |= ImGui.Checkbox("Color Duty Finder", ref ColorContentFinder);
 
         if (ColorContentFinder) {
@@ -183,7 +186,12 @@ public unsafe class DutyRoulette : Modules.DailyTask<DutyRouletteData, DutyRoule
     }
 
     public override void Update() {
-        Data.TaskData.Update(ref DataChanged, rowId => InstanceContent.Instance()->IsRouletteComplete((byte) rowId));
+        Data.TaskData.Update(ref DataChanged, rowId =>
+        {
+            var isExpert = rowId == 5;
+            if (Config.ExpertCompleteWhenCapped && isExpert && Data.AtTomeCap) return true;
+            return InstanceContent.Instance()->IsRouletteComplete((byte)rowId);
+        });
 
         Data.ExpertTomestones = TryUpdateData(Data.ExpertTomestones, InventoryManager.Instance()->GetWeeklyAcquiredTomestoneCount());
         Data.ExpertTomestoneCap = TryUpdateData(Data.ExpertTomestoneCap, InventoryManager.GetLimitedTomestoneWeeklyLimit());


### PR DESCRIPTION
Relates #113 

Adds a setting to consider only expert roulette complete when tomecapped (for example when wanting to be reminded of leveling roulette for leveling alts but don't care about running expert dungeons)

I've only allowed expert roulette to be considered complete since that is realistically the only roulette people are running for the purpose of obtaining tomes. It's faster to run expert dungeons without the roulette bonus than to run other roulettes if all you care about is the weekly tomestone (in terms of tomestones/hr).

Note: `Strings.designer.cs` doesn't generate properly on my dev machine, so I manually edited it to get compilation working, but it'll need to be regenerated. You may also want to format the code to align with your styles.