### PR TITLE
Add: visibility option for Timers tooltip

### DIFF
--- a/DailyDuty/Classes/Timers/TimerNode.cs
+++ b/DailyDuty/Classes/Timers/TimerNode.cs
@@ -45,7 +45,6 @@ public unsafe class TimerNode : NodeBase<AtkResNode> {
 			Size = new Vector2(16.0f, 16.0f),
 			TextColor = KnownColor.White.Vector(),
 			TextOutlineColor = KnownColor.Black.Vector(),
-			IsVisible = true,
 			FontSize = 16,
 			FontType = FontType.Axis,
 			TextFlags = TextFlags.Edge,
@@ -130,6 +129,7 @@ public unsafe class TimerNode : NodeBase<AtkResNode> {
 
 	public void SetStyle(TimerNodeStyle style) {
 		SetStyle(style as NodeBaseStyle);
+		tooltipNode.IsVisible = !System.TimersConfig.HideTimerTooltip;
 		tooltipNode.NodeFlags |= NodeFlags.EmitsEvents | NodeFlags.HasCollision | NodeFlags.RespondToMouse;
 
 		progressBarNode.SetStyle(style.ProgressBarNodeStyle);

--- a/DailyDuty/Localization/Strings.Designer.cs
+++ b/DailyDuty/Localization/Strings.Designer.cs
@@ -789,6 +789,15 @@ namespace DailyDuty.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Hide Info Tooltip.
+        /// </summary>
+        internal static string HideTimerTooltip {
+            get {
+                return ResourceManager.GetString("HideTimerTooltip", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Highest Score.
         /// </summary>
         internal static string HighestScore {

--- a/DailyDuty/Localization/Strings.de.resx
+++ b/DailyDuty/Localization/Strings.de.resx
@@ -665,4 +665,7 @@ Auf einmal pro 5 Minuten limitiert</value>
     <data name="WindowDraggingEnabled" xml:space="preserve">
         <value>Window Dragging Enabled</value>
     </data>
+    <data name="HideTimerTooltip" xml:space="preserve">
+        <value>Infonachricht ausblenden</value>
+    </data>
 </root>

--- a/DailyDuty/Localization/Strings.fr.resx
+++ b/DailyDuty/Localization/Strings.fr.resx
@@ -664,4 +664,7 @@
     <data name="WindowDraggingEnabled" xml:space="preserve">
         <value>Window Dragging Enabled</value>
     </data>
+    <data name="HideTimerTooltip" xml:space="preserve">
+        <value>Masquer le message d'information</value>
+    </data>
 </root>

--- a/DailyDuty/Localization/Strings.ja.resx
+++ b/DailyDuty/Localization/Strings.ja.resx
@@ -665,4 +665,7 @@
     <data name="WindowDraggingEnabled" xml:space="preserve">
         <value>Window Dragging Enabled</value>
     </data>
+    <data name="HideTimerTooltip" xml:space="preserve">
+        <value>情報メッセージを非表示にする</value>
+    </data>
 </root>

--- a/DailyDuty/Localization/Strings.resx
+++ b/DailyDuty/Localization/Strings.resx
@@ -667,4 +667,7 @@ Limited to once per 5 mins</value>
     <data name="WindowDraggingEnabled" xml:space="preserve">
         <value>Window Dragging Enabled</value>
     </data>
+    <data name="HideTimerTooltip" xml:space="preserve">
+        <value>Hide Info Tooltip</value>
+    </data>
 </root>

--- a/DailyDuty/Models/TimersConfig.cs
+++ b/DailyDuty/Models/TimersConfig.cs
@@ -15,6 +15,7 @@ public class TimersConfig {
 	
     public bool HideInDuties = true;
     public bool HideInQuestEvents = true;
+    public bool HideTimerTooltip = false;
 
     public TimerConfig WeeklyTimerConfig = new() {
         Style = new TimerNodeStyle {

--- a/DailyDuty/Windows/ConfigurationWindow.cs
+++ b/DailyDuty/Windows/ConfigurationWindow.cs
@@ -239,6 +239,7 @@ public class TimersConfigTab : ITabItem {
 
             configChanged |= ImGui.Checkbox(Strings.HideInDuties, ref System.TimersConfig.HideInDuties);
             configChanged |= ImGui.Checkbox(Strings.HideInQuestEvent, ref System.TimersConfig.HideInQuestEvents);
+            configChanged |= ImGui.Checkbox(Strings.HideTimerTooltip, ref System.TimersConfig.HideTimerTooltip);
         }
 
         ImGuiHelpers.ScaledDummy(10.0f);


### PR DESCRIPTION
Config toggle to hide "Overlay from DailyDuty Plugin" tooltip.

Added: `HideTimerTooltip` to `TimersConfig`
Moved: `tooltipNode.IsVisible` handling under `SetStyle` so the toggle updates
Included auto-translate strings.

Wanted something minimal like below, but had no option to remove the offset "?".

![image](https://github.com/user-attachments/assets/c7d1193e-8754-4973-9a45-8605c0572b00)

Not a programmer, so it might not be done proper, but it's functional. Was bugging me so thought I'd take a stab at it for a learning experience. Hope it's not too bad lol.