### PR TITLE
Bugfix for Alliance Raid Duty Finder

### DIFF
--- a/DailyDuty/Classes/PayloadController.cs
+++ b/DailyDuty/Classes/PayloadController.cs
@@ -82,11 +82,10 @@ public unsafe class PayloadController : IDisposable {
     }
 
     private static void OpenDutyFinderAllianceRaid() {
-        var currentAllianceRaid = Services.DataManager.GetExcelSheet<ContentFinderCondition>()
-          .Where(cfc => cfc.ContentType.RowId is 5 && cfc is { RequiredExVersion.RowId: 0, Unknown28: true })
-          .Last();
+        var currentAllianceRaid = Services.DataManager.LimitedAllianceRaidDuties.LastOrDefault();
 
         AgentContentsFinder.Instance()->OpenRegularDuty(currentAllianceRaid.RowId);
+        ClearDutyFinderSelection();
     }
 
     private static void OpenDutyFinderRaid() {


### PR DESCRIPTION
Clicking "Raids Alliance" in ToDo List caused an Exception... it would seem "Unknown28" is no longer identifying weekly restrictions. Slight adjustment and works fine now - and should be safe when there is no weekly limited alliance raids - as the module configuration should catch it.